### PR TITLE
Unnecessary variables removed (_deparuteTime)

### DIFF
--- a/Domain/Entites/BusStop/busStopAbstraction.cpp
+++ b/Domain/Entites/BusStop/busStopAbstraction.cpp
@@ -21,7 +21,6 @@ void ABusStop::addBus(double currentTime, unsigned short availableSeats)
 
     while (!_passengers.isEmpty() && availableSeats > 0)
     {
-        _passengers.front().setDepartureTime(currentTime);
         setTotalWaitTime(getTotalWaitTime() + (currentTime - _passengers.front().getArrivalTime()));
         _passengers.dequeue();
         setTotalPassengers(getTotalPassengers() + 1);

--- a/Domain/Entites/Passenger/passengerAbstraction.cpp
+++ b/Domain/Entites/Passenger/passengerAbstraction.cpp
@@ -1,11 +1,8 @@
 #include "passengerAbstraction.h"
 
-APassenger::APassenger() { CREATE_INFO("APassenger <- Default constructor: called;"); setArrivalTime(0.0); setDepartureTime(0.0); }
-APassenger::APassenger(const double& arrivalTime) { CREATE_INFO("APassenger <- Constructor: called;"); setArrivalTime(arrivalTime); setDepartureTime(0.0); }
+APassenger::APassenger() { CREATE_INFO("APassenger <- Default constructor: called;"); setArrivalTime(0.0); }
+APassenger::APassenger(const double& arrivalTime) { CREATE_INFO("APassenger <- Constructor: called;"); setArrivalTime(arrivalTime); }
 APassenger::~APassenger() { CREATE_INFO("APassenger <- Destructor: called;"); }
 
 double APassenger::getArrivalTime() const { INFO("APassenger -> Method getArrivalTime: called;"); return _arrivaleTime; }
 void APassenger::setArrivalTime(const double& value) { INFO("APassenger -> Method setArrivalTime: called;"); _arrivaleTime = value; }
-
-double APassenger::getDepartureTime() const { INFO("APassenger -> Method getDepartureTime: called;"); return _departureTime; }
-void APassenger::setDepartureTime(const double& value) { INFO("APassenger -> Method setDepartureTime: called;"); _departureTime = value; }

--- a/Domain/Entites/Passenger/passengerAbstraction.h
+++ b/Domain/Entites/Passenger/passengerAbstraction.h
@@ -10,7 +10,6 @@ class APassenger abstract
 {
 private:
 	double _arrivaleTime;
-	double _departureTime;
 public:
 	APassenger();
 	APassenger(const double& arrivalTime);
@@ -18,9 +17,6 @@ public:
 
 	double getArrivalTime() const override;
 	void setArrivalTime(const double& value) override;
-
-	double getDepartureTime() const override;
-	void setDepartureTime(const double& value) override;
 };
 
 #endif

--- a/Domain/Entites/Passenger/passengerInterface.h
+++ b/Domain/Entites/Passenger/passengerInterface.h
@@ -6,9 +6,6 @@ class IPassenger
 public:
 	virtual double getArrivalTime() const = 0;
 	virtual void setArrivalTime(const double& value) = 0;
-	
-	virtual double getDepartureTime() const = 0;
-	virtual void setDepartureTime(const double& value) = 0;
 };
 
 #endif

--- a/Presentation/Tests/Tests/passengerTest.cpp
+++ b/Presentation/Tests/Tests/passengerTest.cpp
@@ -10,10 +10,6 @@ void Test::passengerTest()
 	cout << "  setArrivalTime(3.5);" << endl; value0->setArrivalTime(3.5);
 	cout << "  getArrivalTime(). Result: " << value0->getArrivalTime() << ';' << endl;
 	cout << endl;
-
-	cout << "Departire time:" << endl;
-	cout << "  getDepartureTime(). Result: " << value0->getDepartureTime() << ';' << endl;
-	cout << endl;
 	
 	delete value0;
 }

--- a/cfg.h
+++ b/cfg.h
@@ -5,6 +5,6 @@
 bool Logger::_isEnabled = false;
 
 #include "Presentation/Tests/test.h"
-const unsigned short Test::testCounter = 2;
+const unsigned short Test::testCounter = 1;
 
 #endif


### PR DESCRIPTION
Unnecessary variables removed (_deparuteTime)

#### PR Classification
Code cleanup to remove the departure time functionality from the passenger and bus stop classes.

#### PR Summary
Removed the departure time feature from the `APassenger` class and related components.
- `busStopAbstraction.cpp`: Removed setting of departure time in `ABusStop::addBus`.
- `passengerAbstraction.cpp` and `passengerAbstraction.h`: Removed `_departureTime` member and associated methods from `APassenger`.
- `passengerInterface.h`: Removed `getDepartureTime` and `setDepartureTime` methods from `IPassenger`.
- `passengerTest.cpp`: Removed departure time tests from `Test::passengerTest()`.
- `cfg.h`: Updated `Test::testCounter` constant from 2 to 1.
